### PR TITLE
.gitlint: Ignore Signed-off-by lines when checking commit logs

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,5 @@
+[general]
+regex-style-search=true
+
+[ignore-body-lines]
+regex=^(Signed-off|Acked|Co-Authored|Reported|Tested-by)-by:


### PR DESCRIPTION
Without this configuration, gitlint treats lines like Signed-off-by, Acked-by, and others as part of the commit message body and doesn't warn about empty commit messages.

This update ignores these lines (e.g., Signed-off-by, Co-Authored-by) for more accurate commit message checks.