### PR TITLE
west.yml: Fix CMSIS module to use v6 for Cortex-M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -9,6 +9,7 @@ manifest:
       import:
         name-allowlist:
           - cmsis
+          - cmsis_6
 
     - name: libcsp
       url: https://github.com/libcsp/libcsp


### PR DESCRIPTION
Zephyr has migrated to CMSIS v6. While the plan was to transition all ARM architectures, issues with Cortex-A and Cortex-R prevented full adoption. As a result, only Cortex-M was updated to v6 in zephyrproject-rtos/zephyr#89370.

Since the SC-OBC module A1 uses a Cortex-M3, we need to adopt CMSIS v6.

That PR was merged after Zephyr v4.1.0, so older versions may still require the legacy CMSIS module. To maintain compatibility, we are keeping the old module alongside v6.