### PR TITLE
buffer: Fix buffer fail test

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -9,6 +9,7 @@ manifest:
       import:
         name-allowlist:
           - cmsis
+          - cmsis_6
 
     - name: libcsp
       url: https://github.com/libcsp/libcsp


### PR DESCRIPTION
* I add the commit of @yashi to fix the build problem also. (Even if it's from another PR)

Recent changes in libcsp introduced a reserved buffer mechanism in `csp_buffer_get()`, which prevents the last two buffers from being allocated using this function. To test the full buffer usage, we now use `csp_buffer_get_always()`, which bypasses the reservation and allows allocating all available buffers.

However, calling `csp_buffer_get_always()` when no buffers are left triggers `csp_panic()`. In this test, we redefine `csp_panic()` to simulate a panic without aborting the test execution. This allows us to verify that `csp_buffer_get_always()` correctly triggers a panic when over-allocating.

This change fixes the test failure caused by the new buffer reservation logic.

Due to the new logic in `csp_buffer_get()`, additional tests should be added to cover this updated behavior.
I can take care of adding those in a separate PR if that works for you.